### PR TITLE
fix: resolve blank page residue and wrong window focusing on PIP restore

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,63 +1,119 @@
-let dummyTabId = null;
-let originalTabId = null;
-let state = false;
+let dummyTabId: number | null = null;
+let originalTabId: number | null = null;
+let originalWindowId: number | null = null;
+
+let isFirefoxFocused = true;
+let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+let activeWindowId: number | null = null;
+let activeTabId: number | null = null;
+
+browser.windows.getCurrent().then(async (win) => {
+	if (win && win.id !== undefined) {
+		activeWindowId = win.id;
+		try {
+			const tabs = await browser.tabs.query({ active: true, windowId: win.id });
+			if (tabs.length > 0) activeTabId = tabs[0].id ?? null;
+		} catch {}
+	}
+});
+
+browser.tabs.onActivated.addListener((activeInfo) => {
+	if (activeInfo.tabId === dummyTabId) return;
+
+	activeWindowId = activeInfo.windowId;
+	activeTabId = activeInfo.tabId;
+});
 
 async function handleFocusLoss() {
-	const currentTab = await browser.tabs.query({ active: true, currentWindow: true });
+	if (dummyTabId !== null) return;
+	if (!activeWindowId || !activeTabId) return;
 
-	if (!currentTab[0].audible) {
+	try {
+		const tab = await browser.tabs.get(activeTabId);
+		if (!tab || !tab.audible) return;
+
+		if (isFirefoxFocused) return;
+
+		originalTabId = activeTabId;
+		originalWindowId = activeWindowId;
+
+		const dummyTab = await browser.tabs.create({
+			windowId: originalWindowId,
+			url: 'about:blank',
+			active: false,
+		});
+
+		if (isFirefoxFocused) {
+			if (dummyTab.id !== undefined) {
+				try {
+					await browser.tabs.remove(dummyTab.id);
+				} catch {}
+			}
+			return;
+		}
+
+		dummyTabId = dummyTab.id ?? null;
+
+		timeoutId = setTimeout(async () => {
+			if (dummyTabId && !isFirefoxFocused) {
+				try {
+					await browser.tabs.update(dummyTabId, { active: true });
+				} catch {}
+			}
+		}, 50);
+	} catch {}
+}
+
+async function handleFocusGain(focusedWindowId: number) {
+	if (timeoutId) {
+		clearTimeout(timeoutId);
+		timeoutId = null;
+	}
+
+	if (!dummyTabId || !originalTabId || !originalWindowId) {
+		activeWindowId = focusedWindowId;
+		try {
+			const tabs = await browser.tabs.query({ active: true, windowId: focusedWindowId });
+			if (tabs.length > 0) activeTabId = tabs[0].id ?? null;
+		} catch {}
 		return;
 	}
 
-	originalTabId = currentTab[0].id;
+	const dTabId = dummyTabId;
+	const oTabId = originalTabId;
+	const oWinId = originalWindowId;
 
-	const dummyTab = await browser.tabs.create({
-		url: 'about:blank',
-		active: false,
-	});
+	dummyTabId = null;
+	originalTabId = null;
+	originalWindowId = null;
 
-	dummyTabId = dummyTab.id;
+	try {
+		await browser.tabs.update(oTabId, { active: true });
+		await browser.tabs.remove(dTabId);
+	} catch {
+		// Original tab or dummy tab might have been closed
+	}
 
-	setTimeout(async () => {
-		await browser.tabs.update(dummyTabId, { active: true });
-	}, 50);
-}
-
-async function handleFocusGain() {
-	if (!dummyTabId) return;
-
-	const currentTab = await browser.tabs.query({ active: true, currentWindow: true });
-
-	await new Promise((resolve) => setTimeout(resolve, 10));
-
-	if (currentTab[0].id === dummyTabId) {
-		await browser.tabs.remove(dummyTabId);
-		dummyTabId = null;
-
+	if (focusedWindowId !== oWinId) {
 		try {
-			await browser.tabs.get(originalTabId);
-			await browser.tabs.update(originalTabId, { active: true });
-		} catch {
-			// Original tab was closed
-		}
+			// Force focus back to the original window
+			await browser.windows.update(oWinId, { focused: true });
+		} catch {}
+	} else {
+		activeWindowId = focusedWindowId;
+		activeTabId = oTabId;
 	}
 }
 
 browser.windows.onFocusChanged.addListener(async (windowId) => {
-	if (state) {
-		return;
-	}
+	const hasFocus = windowId !== browser.windows.WINDOW_ID_NONE;
+	isFirefoxFocused = hasFocus;
 
-	state = true;
-
-	try {
-		if (windowId === browser.windows.WINDOW_ID_NONE) {
-			await handleFocusLoss();
-		} else {
-			await handleFocusGain();
-		}
-	} finally {
-		state = false;
+	if (hasFocus) {
+		await handleFocusGain(windowId);
+	} else {
+		await handleFocusLoss();
 	}
 });
 
@@ -65,5 +121,6 @@ browser.tabs.onRemoved.addListener((tabId) => {
 	if (tabId === dummyTabId) {
 		dummyTabId = null;
 		originalTabId = null;
+		originalWindowId = null;
 	}
 });


### PR DESCRIPTION
Hi! I found a few issues when switching focuses in Firefox and fixed them in this PR:

1. **Blank page residue**: Sometimes `about:blank` isn't properly closed when switching back quickly.
2. **Wrong window focus**: In a multi-window setup, OS/Firefox might restore focus to the most recently created window instead of the original video window, causing the extension to fail to clean up the dummy tab.

**Changes made:**
- Replaced global boolean state with exact tracking of `activeWindowId` and `activeTabId` via `browser.tabs.onActivated`.
- Guaranteed cleanup of the dummy tab regardless of which window gets focused.
- Added a fallback to forcefully bring the original video window to the foreground if the OS incorrectly focuses a background window.

*(Note: The code changes and logic for this fix were generated with the assistance of AI.)*